### PR TITLE
Integrated the config parser, webserver now reads settings from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC=g++
 
 CFLAGS=-g -std=c++11 -lboost_system -Wall -Werror -lpthread
-HEADERS=HttpResponse.h HttpRequest.h HttpMessage.h server.h connection.h
-SOURCES=main.cpp server.cpp connection.cpp
+HEADERS=HttpResponse.h HttpRequest.h HttpMessage.h server.h connection.h nginx-configparser/config_parser.h
+SOURCES=main.cpp server.cpp connection.cpp nginx-configparser/config_parser.cc
 all: webserver
 
 webserver : $(SOURCES) $(HEADERS)

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,32 @@
-
 #include "server.h"
 #include <iostream>
 #include <boost/version.hpp>
+#include "nginx-configparser/config_parser.h"
+#include <vector>
+#include <unordered_map>
+using namespace std;
+
 int main(int argc, char** argv) {
-  Team15::server::server s("127.0.0.1","4000");
+
+  NginxConfigParser config_parser;
+  NginxConfig config;
+  config_parser.Parse(argv[1], &config);
+
+  unordered_map<string, string> valuePairs;
+
+  // loops through the statements in the config and creates value pairs
+  // NOTE: DOES NOT WORK FOR CHILD BLOCKS YET;
+
+  for (int k = 0; k < (int) config.statements_.size();k++) { 
+  	string token1 = config.statements_[k]->tokens_[0];
+  	string token2 = config.statements_[k]->tokens_[1];
+  	valuePairs.insert({token1, token2});
+  }
+
+  printf("%s\n", valuePairs["listen"].c_str());
+  printf("%s\n", valuePairs["server_name"].c_str());
+
+  Team15::server::server s(valuePairs["server_name"],valuePairs["listen"]);
   
   s.run();
 

--- a/test_config
+++ b/test_config
@@ -1,0 +1,2 @@
+listen 4000;
+server_name 127.0.0.1;


### PR DESCRIPTION
Finished the integration stuff. It only works for configs WITHOUT child blocks though. Couldn't get that to work b/c of the weird std::unique_ptr type. Will get back to it later, but for now the webserver can read the port and server_name from the config in test_config.